### PR TITLE
Revert to cuda-toolkit from nvidia channel

### DIFF
--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -1,6 +1,7 @@
 name: pytorch-dev
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.8
   - numpy
@@ -36,13 +37,37 @@ dependencies:
   - sysroot_linux-64>=2.17
   # cuda stuff
   - magma
-  - cuda-version=12.0
-  - cudnn
-  # The following 6 packages install cudatoolkit
+  - cuda-version=12.1
+  - cudnn # nvidia::cudnn is too old
+  # The following packages install cudatoolkit
   # Not necessary in qgpu as it's installed system-wide
-  - cuda-libraries-dev
-  - cuda-nvcc
-  - cuda-gdb
-  - cuda-nvtx-dev
-  - cuda-nvml-dev
-  - cuda-cupti
+  # NOTE: We need to avoid installing cudatoolkit from conda-forge
+  # as it doesn't play well with pytorch or its domain libraries
+  - nvidia/label/cuda-12.1.0::cuda-libraries-dev
+  - nvidia/label/cuda-12.1.0::cuda-nvcc
+  - nvidia/label/cuda-12.1.0::cuda-gdb
+  - nvidia/label/cuda-12.1.0::cuda-nvtx
+  - nvidia/label/cuda-12.1.0::cuda-nvml-dev
+  - nvidia/label/cuda-12.1.0::cuda-nvrtc
+  - nvidia/label/cuda-12.1.0::cuda-nvrtc-dev
+  - nvidia/label/cuda-12.1.0::cuda-cupti
+  - nvidia/label/cuda-12.1.0::cuda-cudart
+  - nvidia/label/cuda-12.1.0::cuda-cudart-dev
+  - nvidia/label/cuda-12.1.0::cuda-cudart-static
+  - nvidia/label/cuda-12.1.0::cuda-cccl
+  - nvidia/label/cuda-12.1.0::cuda-opencl
+  - nvidia/label/cuda-12.1.0::cuda-opencl-dev
+  - nvidia/label/cuda-12.1.0::cuda-driver-dev
+  - nvidia/label/cuda-12.1.0::cuda-profiler-api
+  - nvidia/label/cuda-12.1.0::libcufft
+  - nvidia/label/cuda-12.1.0::libcublas
+  - nvidia/label/cuda-12.1.0::libcurand
+  - nvidia/label/cuda-12.1.0::libcufile
+  - nvidia/label/cuda-12.1.0::libcusparse
+  - nvidia/label/cuda-12.1.0::libcusolver
+
+  # Compilers (optional, but recommended)
+  - gcc=12
+  - gxx=12
+  - c-compiler
+  - cxx-compiler

--- a/torch-common.sh
+++ b/torch-common.sh
@@ -45,14 +45,7 @@ export CMAKE_PREFIX_PATH=$CONDA_PREFIX
 # Use cudatoolkit from conda (see pytorch-dev.yaml)
 # If you have it installed system-wide (e.g. in qgpu) point CUDA_PATH and CMAKE_CUDA_COMPILER
 # to the right folder
-#
-# Note: targets/x86_64-linux is added because of the use of deprecated find_package(CUDA).
-# Usually `cuda_runtime.h` is found in CUDA_HOME and find_package(CUDA) expects that.
-# However with conda, cuda headers are in $CUDA_HOME/targets/x86_64-linux/include
-# instead of $CUDA_HOME/include to avoid cloberring the top level directory with names like
-# mma.h. The new way `enable_languages(CUDA)` knows about this, but pytorch uses both
-# mechanisms.
-export CUDA_PATH=$CONDA_PREFIX/targets/x86_64-linux
+export CUDA_PATH=$CONDA_PREFIX
 export CUDA_HOME=$CUDA_PATH
 export CMAKE_CUDA_COMPILER=$CONDA_PREFIX/bin/nvcc
 


### PR DESCRIPTION
I've had quite a bit of trouble trying to get torchbench compiled using the conda-forge cudatoolkit due to its split install. Lets just move back to the nvidia channels, but I've adapted the previous version so it doesn't mix and match cuda installs by explicitly installing everything except cudnn from nvidia's channels.