### PR TITLE
Use CUDA 12.2 and rehash a bit the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,11 @@
 
 ### Setting up the environment
 
-**Optional: Installing an older compiler**.
-If you want to go the extra mile, you can install gcc 9, as this is the minimum required version.
-This will help you make sure the code you write works on these compilers.
-To do this, add `gxx=9` to `pytorch-dev.yaml` file. At the time of this writing, building with conda
-gxx=9 requires cuda-nvcc to be installed from conda as well.
-
-- [If you don't have them] Install the Nvidia drivers from https://www.nvidia.com/download/index.aspx
-
-- Set the correct CUDA version in `pytorch-dev.yaml` by changing the line `cuda-version=12.0`
+- Set the correct CUDA version in `pytorch-dev.yaml` by changing the line `cuda-version=12.2`
 
 - Create the conda environment: `conda env create -f pytorch-dev.yaml`
+
+- [If you don't have them] Install the Nvidia drivers from https://www.nvidia.com/download/index.aspx
 
 **Python version**. We set python=3.8 in `pytorch-dev.yaml`, as this is the minimum required version in PyTorch, and this disallows us from using features that are "too new".
 To debug some issues that may not reproduce on Python 3.8, you may need to create a different env with a newer Python version.

--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -42,7 +42,7 @@ dependencies:
   - cuda-driver-dev
   # cuda stuff
   - magma
-  - cuda-version=12.1
+  - cuda-version=12.2
   - cudnn
   # The following 6 packages install cudatoolkit
   # Not necessary in qgpu as it's installed system-wide

--- a/torch-common.sh
+++ b/torch-common.sh
@@ -43,8 +43,8 @@ export USE_MEM_EFF_ATTENTION=0
 export CMAKE_PREFIX_PATH=$CONDA_PREFIX
 
 # Use cudatoolkit from conda (see pytorch-dev.yaml)
-# If you have it installed system-wide (e.g. in qgpu) point CUDA_PATH and CMAKE_CUDA_COMPILER
-# to the right folder
+# If you have it installed system-wide (e.g. in qgpu) and you want to use it,
+# point CUDA_PATH and CMAKE_CUDA_COMPILER to the right folder
 export CUDA_PATH=$CONDA_PREFIX
 export CUDA_HOME=$CUDA_PATH
 export CMAKE_CUDA_COMPILER=$CONDA_PREFIX/bin/nvcc


### PR DESCRIPTION
Using CUDA 12.2, as CUDA 12.1 is not offered at https://www.nvidia.com/download/index.aspx.
I also removed the point in the README regarding gcc-9 as it was not particularly helpful.
I also changed the order: first conda, then install drivers. This makes sense now given that we are fully using conda compilers. 