### PR TITLE
Update to most recent supported CUDA and GCC

### DIFF
--- a/pytorch-dev-freethreading.yaml
+++ b/pytorch-dev-freethreading.yaml
@@ -10,13 +10,15 @@ dependencies:
 
   # Select compiler-version (optional, but recommended)
   # These are pulled in by cuda-nvcc implicitly
-  - gcc=12
-  - gxx=12
+  - gcc=13
+  - gxx=13
+  # Add GDB, to bundle in py-bt support.
+  - gdb
 
   # CUDA requirements, even if using system CUDA
   - magma
   - cuda-driver-dev
-  - cuda-version=12.4
+  - cuda-version=12.6
   - cudnn
   - conda-gcc-specs # Needed for triton to find libcuda.so
 
@@ -82,7 +84,3 @@ dependencies:
 
   # torch.compile halide backend
   #- halide-python
-
-  # torchbench dependencies that may cause issues if installed by pip
-  # - pandas
-  # - transformers

--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -9,13 +9,15 @@ dependencies:
 
   # Select compiler-version (optional, but recommended)
   # These are pulled in by cuda-nvcc implicitly
-  - gcc=12
-  - gxx=12
+  - gcc=13
+  - gxx=13
+  # Add GDB, to bundle in py-bt support.
+  - gdb
 
   # CUDA requirements, even if using system CUDA
   - magma
   - cuda-driver-dev
-  - cuda-version=12.4
+  - cuda-version=12.6
   - cudnn
   - conda-gcc-specs # Needed for triton to find libcuda.so
 
@@ -80,7 +82,3 @@ dependencies:
 
   # torch.compile halide backend
   - halide-python
-
-  # torchbench dependencies that may cause issues if installed by pip
-  # - pandas
-  # - transformers


### PR DESCRIPTION
Updates to CUDA 12.6, the most recent supported version by PyTorch. Additionally updates GCC to 13.x, which is supported by CUDA 12.6, and adds `gdb` install to get the `py-bt` command.