### PR TITLE
Remove torch-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 ### Structure of a PyTorch build directory
 
-A PyTorch build directory contains six subdirectories:
+A PyTorch build directory contains five subdirectories:
 
 :- `pytorch/`
 - `torchbenchmark/`
 - `torch-audio/`
 - `torch-data/`
-- `torch-text/`
 - `torch-vision/`
 
 There is also the directory containing this file, `torch-build/`, which can be anywhere

--- a/torch-build.sh
+++ b/torch-build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/pytorch-build.sh $@
 
 
-PKGS=(data vision text audio)
+PKGS=(data vision audio)
 
 export BUILD_SOX=0
 

--- a/torch-clone.sh
+++ b/torch-clone.sh
@@ -15,7 +15,7 @@ fi
 popd
 
 # Domain Libraries
-PKGS=(data vision text audio)
+PKGS=(data vision audio)
 for pkg in ${PKGS[@]}; do
 	git clone git@github.com:pytorch/${pkg}.git "torch-${pkg}"
 done

--- a/torch-update.sh
+++ b/torch-update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-PKGS=(pytorch torch-data torch-vision torch-text torch-audio torchbenchmark)
+PKGS=(pytorch torch-data torch-vision torch-audio torchbenchmark)
 
 cd ${PYTORCH_BUILD_DIRECTORY:=~/git$PYTORCH_BUILD_SUFFIX}
 


### PR DESCRIPTION
Per torch-text commit [40dbc55cee91fb493376006b278cba8688cdb7c0](https://github.com/pytorch/text/commit/40dbc55cee91fb493376006b278cba8688cdb7c0), there will be no future releases of torch-text. The current release is broken with CMake 4.0, which is now used by torch-build and by the PyTorch CI, so it's time to remove it.