### PR TITLE
Update dependencies

### DIFF
--- a/pytorch-dev-freethreading.yaml
+++ b/pytorch-dev-freethreading.yaml
@@ -10,8 +10,8 @@ dependencies:
 
   # Select compiler-version (optional, but recommended)
   # These are pulled in by cuda-nvcc implicitly
-  - gcc=13
-  - gxx=13
+  - gcc=14
+  - gxx=14
   # Add GDB, to bundle in py-bt support.
   - gdb
   # Certain features (like cpp_wrapper for inductor) can be tested in clang as
@@ -23,7 +23,7 @@ dependencies:
   # CUDA requirements, even if using system CUDA
   - magma
   - cuda-driver-dev
-  - cuda-version=12.6
+  - cuda-version=12.9
   - cudnn
   - conda-gcc-specs # Needed for triton to find libcuda.so
 
@@ -61,6 +61,7 @@ dependencies:
   #- scipy
   - psutil
   - pytest
+  - parameterized
 
   # Development utilities
   #- ghstack

--- a/pytorch-dev-macos.yaml
+++ b/pytorch-dev-macos.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip
   - cpython
   - compilers
@@ -30,6 +30,7 @@ dependencies:
   - scipy
   - psutil
   - pytest
+  - parameterized
 
   # Development utilities
   - ghstack

--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip
   - cpython
 
   # Select compiler-version (optional, but recommended)
   # These are pulled in by cuda-nvcc implicitly
-  - gcc=13
-  - gxx=13
+  - gcc=14
+  - gxx=14
   # Add GDB, to bundle in py-bt support.
   - gdb
   # Certain features (like cpp_wrapper for inductor) can be tested in clang as
@@ -22,7 +22,7 @@ dependencies:
   # CUDA requirements, even if using system CUDA
   - magma
   - cuda-driver-dev
-  - cuda-version=12.6
+  - cuda-version=12.9
   - cudnn
   - conda-gcc-specs # Needed for triton to find libcuda.so
 
@@ -63,6 +63,7 @@ dependencies:
   - scipy
   - psutil
   - pytest
+  - parameterized
 
   # Development utilities
   - ghstack


### PR DESCRIPTION
* Update the base Python version to 3.10, in line with the planned removal of 3.9 support in the next PyTorch release (pytorch/pytorch/issues/161167).
* Update to the latest supported CUDA version 12.9, for performance.
* Update to GCC 14, which is supported by CUDA 12.9.
* Add parameterized, a test dependency of parts of PyTorch.